### PR TITLE
feat(workflow): add release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,31 @@
+on:
+  workflow_dispatch:
+    inputs:
+      releaseVersion:
+        type: string
+        description: New version for the release.
+        required: true
+jobs:
+  release:
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          fetch-depth: 0
+      - name: Tag release
+        shell: sh
+        env:
+          RELEASE_VERSION: ${{ inputs.releaseVersion }}
+        run: |
+          git tag -a "${RELEASE_VERSION}" -m "Release ${RELEASE_VERSION}"
+          git push origin "${RELEASE_VERSION}"
+          gh release create "${RELEASE_VERSION}" \
+            --repo="$GITHUB_REPOSITORY" \
+            --generate-notes \
+            --latest \
+            --title "${RELEASE_VERSION}"
+
+


### PR DESCRIPTION
 - Introduced a new GitHub Actions workflow (release.yml) to streamline the release process.
- Allows manual triggering with a required releaseVersion input.
- Steps include:
  - Checking out the repository with full history.
  - Creating a new annotated Git tag for the release.
  - Pushing the tag to the remote repository.
  - Generating a new GitHub release with the provided version, auto-generated release notes, and marking it as the latest.

This enhancement ensures a consistent and automated approach for version tagging and release management.