### PR TITLE
fix(workflow): configure git user for release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,6 +20,8 @@ jobs:
         env:
           RELEASE_VERSION: ${{ inputs.releaseVersion }}
         run: |
+          git config --global user.email "${GITHUB_ACTOR_ID}+${GITHUB_ACTOR}@users.noreply.github.com"
+          git config --global user.name "${GITHUB_ACTOR}"
           git tag -a "${RELEASE_VERSION}" -m "Release ${RELEASE_VERSION}"
           git push origin "${RELEASE_VERSION}"
           gh release create "${RELEASE_VERSION}" \


### PR DESCRIPTION
- Added global configuration for user.email and user.name in the `release.yml` workflow:
- Uses `${GITHUB_ACTOR_ID}+${GITHUB_ACTOR}@users.noreply.github.com` for the email.
- Sets `${GITHUB_ACTOR}` as the user name.
- Ensures that Git commands like tagging and pushing operate without user identity issues in the release process.

This update prevents potential failures due to missing Git user configuration during workflow execution.