### PR TITLE
fix(workflow): include GitHub token for release creation

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,6 +19,7 @@ jobs:
         shell: sh
         env:
           RELEASE_VERSION: ${{ inputs.releaseVersion }}
+          GH_TOKEN: ${{ github.token }}
         run: |
           git config --global user.email "${GITHUB_ACTOR_ID}+${GITHUB_ACTOR}@users.noreply.github.com"
           git config --global user.name "${GITHUB_ACTOR}"


### PR DESCRIPTION
- Added `GH_TOKEN` to the release workflow environment variables to enable authenticated GitHub API requests.
- Ensures that `gh release create` has the necessary credentials to execute successfully.
- Maintains compatibility with existing environment setup while resolving potential authentication issues.