### PR TITLE
fix(action): use GITHUB_ACTION_PATH for script execution

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -50,9 +50,9 @@ runs:
         SSH_KNOWN_HOSTS: ${{ inputs.ssh-known-hosts }}
       with:
         main: |
-          sh action.sh
+          sh "${{ github.action_path }}/action.sh"
         post: |
-          sh post_action.sh
+          sh "${{ github.action_path }}/post_action.sh"
 branding:
   icon: loader
   color: 'purple'


### PR DESCRIPTION
- Replaced hardcoded script paths with `${{ github.action_path }}` to ensure compatibility in different environments.
- Adjusted paths for `action.sh` and `post_action.sh` accordingly.